### PR TITLE
Fix timeout by bumping bdd interface

### DIFF
--- a/lib/mocha-fibers.js
+++ b/lib/mocha-fibers.js
@@ -2,6 +2,7 @@
 // and it methods all run within fibers.
 
 var mocha = require('mocha'),
+    bdd = mocha.interfaces.bdd,
     Suite = mocha.Suite,
     Test = mocha.Test,
     _ = require('underscore'),
@@ -38,71 +39,9 @@ function fiberize(fn){
 
 // A copy of bdd interface, but wrapping everything in fibers
 module.exports = function(suite){
-  var suites = [suite];
+  bdd(suite);
 
   suite.on('pre-require', function(context){
-
-    // noop variants
-
-    context.xdescribe = function(){};
-    context.xit = function(){};
-
-    /**
-     * Execute before running tests.
-     */
-
-    context.before = function(fn){
-
-      suites[0].beforeAll(fn);
-    };
-
-    /**
-     * Execute after running tests.
-     */
-
-    context.after = function(fn){
-      suites[0].afterAll(fn);
-    };
-
-    /**
-     * Execute before each test case.
-     */
-
-    context.beforeEach = function(fn){
-      suites[0].beforeEach(fn);
-    };
-
-    /**
-     * Execute after each test case.
-     */
-
-    context.afterEach = function(fn){
-      suites[0].afterEach(fn);
-    };
-
-    /**
-     * Describe a "suite" with the given `title`
-     * and callback `fn` containing nested suites
-     * and/or tests.
-     */
-
-    context.describe = context.context = function(title, fn){
-      var suite = Suite.create(suites[0], title);
-      suites.unshift(suite);
-      fn();
-      suites.shift();
-    };
-
-    /**
-     * Describe a specification or test-case
-     * with the given `title` and callback `fn`
-     * acting as a thunk.
-     */
-
-    context.it = context.specify = function(title, fn){
-      suites[0].addTest(new Test(title, fn));
-    };
-
 
     // Wrap test related methods in fiber
     ['beforeEach', 'afterEach', 'after', 'before', 'it'].forEach(function(method){

--- a/test/mocha-fibers.js
+++ b/test/mocha-fibers.js
@@ -5,10 +5,10 @@ describe('mocha-fibers', function(){
   this.timeout(5000);
 
   beforeEach(function(){
-  assert(Fiber.current);
+    assert(Fiber.current);
   });
 
   it('should be in fiber', function(){
-  assert(Fiber.current);
+    assert(Fiber.current);
   });
 });


### PR DESCRIPTION
[Suite level timeouts](http://visionmedia.github.io/mocha/#suite-specific-timeouts) like:

``` js
describe('a suite of tests', function(){
  this.timeout(500);  // <------ This

  it('should take less than 500ms', function(done){
    setTimeout(done, 300);
  })
})
```

Stopped working for me when I require mocha-fibers.  Looks like the BDD interface has changed a bit since this file was copied.  I tried layering the fibers wrapping on top of the interface exported by mocha to avoid future synchronization issues.  Works for all my tests.  Whatcha think?  Also, thanks for writing this.
