### PR TITLE
Errors passed to done callback are ignored

### DIFF
--- a/lib/mocha-fibers.js
+++ b/lib/mocha-fibers.js
@@ -18,9 +18,7 @@ function fiberize(fn){
 
       try{
         if(fn.length == 1){
-          fn.call(self, function(){
-            done();
-          });
+          fn.call(self, done);
         } else {
           fn.call(self);
           done();


### PR DESCRIPTION
If your test function calls `done` with an error, we should pass that error to mocha's `done` callback as well in order to fail the test. Otherwise we'll be hiding errors.

```
  it('always fails', function (done) {
    done(new Error("This test should fail"));
  });
```

I wasn't sure how to write a test for this because we need to pass an error in the test, but not fail the test... We could re-write the module structure so tests have access to `fiberize` but don't expose it to anything external to the module. Then you could make better unit tests around `fiberize` but that's out of scope for this pull request.
