### PR TITLE
add tests for error handling

### DIFF
--- a/test/fixtures/async_error.js
+++ b/test/fixtures/async_error.js
@@ -1,0 +1,9 @@
+
+describe('mocha-fibers', function(){
+  it('should callback with async errors', function(done) {
+    process.nextTick(function() {
+      done(new Error('foo'));
+    });
+  });
+});
+

--- a/test/fixtures/sync_error.js
+++ b/test/fixtures/sync_error.js
@@ -1,0 +1,7 @@
+
+describe('mocha-fibers', function(){
+  it('should callback with sync errors', function(){
+    xxx;
+  });
+});
+

--- a/test/mocha-fibers.js
+++ b/test/mocha-fibers.js
@@ -1,5 +1,8 @@
 var assert = require('assert');
 var Fiber = require('fibers');
+var exec = require('child_process').exec;
+
+var MOCHA_BIN = './node_modules/.bin/mocha --ui ../../../lib/mocha-fibers.js'
 
 describe('mocha-fibers', function(){
   beforeEach(function(){
@@ -8,5 +11,21 @@ describe('mocha-fibers', function(){
 
   it('should be in fiber', function(){
 	assert(Fiber.current);
+  });
+
+  it('should callback with sync errors', function(done){
+    exec(MOCHA_BIN+' test/fixtures/sync_error.js', function(err, stdout, stderr) {
+      assert(stderr.match(/mocha-fibers should callback with sync errors/));
+      assert(stderr.match(/ReferenceError: xxx is not defined/));
+      done();
+    });
+  });
+
+  it('should callback with async errors', function(done){
+    exec(MOCHA_BIN+' test/fixtures/async_error.js', function(err, stdout, stderr) {
+      assert(stderr.match(/mocha-fibers should callback with async errors/));
+      assert(stderr.match(/Error: foo/));
+      done();
+    });
   });
 });


### PR DESCRIPTION
This PR adds two tests to cover handling of sync and async errors in mocha-fibers.  Would you also publish a new version to npm that incorporates #5?

Thanks!
--Bob
