### PR TITLE
Repair it.skip and it.only

### DIFF
--- a/lib/mocha-fibers.js
+++ b/lib/mocha-fibers.js
@@ -43,13 +43,15 @@ module.exports = function(suite){
 
     // Wrap test related methods in fiber
     ['beforeEach', 'afterEach', 'after', 'before', 'it'].forEach(function(method){
-      context[method] = _.wrap(context[method], function(fn){
+      var original = context[method];
+      context[method] = _.wrap(original, function(fn){
         var args = Array.prototype.slice.call(arguments, 1);
         if(_.isFunction(_.last(args))){
           args.push(fiberize(args.pop()));
         }
-        fn.apply(this, args);
+        return fn.apply(this, args);
       });
+      _.extend(context[method], _(original).pick('only', 'skip'));
     });
 
   });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "bdd style interface wrapped in fibers",
   "main": "./lib/mocha-fibers",
   "scripts": {
-    "test": "./node_modules/.bin/mocha --ui ../../../lib/mocha-fibers.js"
+    "test": "mocha --ui ../../../lib/mocha-fibers.js"
   },
   "dependencies": {
     "underscore": "~1.5.2",

--- a/test/mocha-fibers.js
+++ b/test/mocha-fibers.js
@@ -30,4 +30,10 @@ describe('mocha-fibers', function(){
       done();
     });
   });
+
+  describe('skipped tests', function() {
+    it.skip('should not run', function() {
+      assert(false);
+    });
+  });
 });


### PR DESCRIPTION
Apparently #4 only fixed #1 for `describe` blocks, not `it`.  This PR fixes `it` with tests.
