### PR TITLE
Fix it.only('title', function() { /* test */ } to execute just that test with fibers

### DIFF
--- a/lib/mocha-fibers.js
+++ b/lib/mocha-fibers.js
@@ -52,6 +52,13 @@ module.exports = function(suite){
         return fn.apply(this, args);
       });
       _.extend(context[method], _(original).pick('only', 'skip'));
+      if (context[method].only) {
+        context[method].only = function(only) {
+          return function(title, fn) {
+            return only(title, fiberize(fn));
+          }
+        }(context[method].only);
+      }
     });
 
   });


### PR DESCRIPTION
Currently I think the `it` will `fiberize` the second function argument, but `it.only` will not. Which causes unit tests that use fibers to fail when we try to run just that one test.